### PR TITLE
update sklearn cross_val_score import location

### DIFF
--- a/Tutorial4_naive_bayes_classifier.ipynb
+++ b/Tutorial4_naive_bayes_classifier.ipynb
@@ -47,7 +47,7 @@
     "import nltk\n",
     "from sklearn.naive_bayes import BernoulliNB, MultinomialNB\n",
     "from sklearn.metrics import accuracy_score\n",
-    "from sklearn.cross_validation import cross_val_score\n",
+    "from sklearn.model_selection import cross_val_score\n",
     "nltk.download('movie_reviews')"
    ]
   },


### PR DESCRIPTION
This now errors because a sklearn submodule was deprecated. `cross_val_score` was moved from `cross_validation` to `model_selection`

see https://stackoverflow.com/questions/30667525/importerror-no-module-named-sklearn-cross-validation